### PR TITLE
fix : fix vads_bank_label issue magic_quotes

### DIFF
--- a/lib/class-payment-form-toolbox.php
+++ b/lib/class-payment-form-toolbox.php
@@ -236,7 +236,7 @@ class paymentFormToolbox {
         foreach ($fields as $nom => $valeur) {
             if(substr($nom,0,5) == 'vads_') {
                 // Concatenation with  "+"
-                $signature_content  .= $valeur."+";
+                $signature_content  .= stripslashes($valeur)."+";
             }
         }
         // Adding the certificate at the end


### PR DESCRIPTION
When bank name contains a ' (like Caisse d\'epargne) the signature calc failed 